### PR TITLE
Adding WordPress to socialnav

### DIFF
--- a/inc/socialnav.php
+++ b/inc/socialnav.php
@@ -134,6 +134,10 @@ function unite_social_css(){ ?>
         .fa-soundcloud:before {
             content: "\f1be"
         }
+        #social li a[href*="profiles.wordpress.org"] .fa:before,
+        .fa-wordpress:before {
+            content: "\f19a"
+        }
         
         .social-icons li a[href*="facebook.com"]:hover {color: #3b5998 !important;}
         .social-icons li a[href*="twitter.com"]:hover {color: #00aced !important;}
@@ -154,6 +158,7 @@ function unite_social_css(){ ?>
         .social-icons li a[href*="vimeo.com"]:hover {color:  #1bb6ec !important;}
         .social-icons li a[href*="spotify.com"]:hover {color: #81b71a !important;}
         .social-icons li a[href*="/feed"]:hover {color: #f39c12 !important;}
+        .social-icons li a[href*="profiles.wordpress.org"]:hover {color: #21759A !important;}
     </style><?php
 }
 add_action( 'wp_head', 'unite_social_css', 10 );


### PR DESCRIPTION
Hi, The Unite theme is a really good WP theme, but the one thing I thought it was missing was the possibility of adding a link to a WordPress profile in the social links section.

I've added the code attached to allow profiles.wordpress.org/aprofile to display with the socialnav icons using the Font Awesome code: "\f19a" to display the WordPress icon and the colour: "#21759A" to match one of the many WordPress icon colours available (Every copy of the icon seems to be a different shade of blue or grey!)

Jim